### PR TITLE
Launch error log fix

### DIFF
--- a/tools/roslaunch/src/roslaunch/core.py
+++ b/tools/roslaunch/src/roslaunch/core.py
@@ -423,13 +423,14 @@ class Node(object):
                  'remap_args', 'env_args',\
                  'process_name', 'output', 'cwd',
                  'launch_prefix', 'required',
-                 'filename']
+                 'filename', 'max_logfile_size', 'logfile_count']
 
     def __init__(self, package, node_type, name=None, namespace='/', \
                  machine_name=None, args='', \
                  respawn=False, respawn_delay=0.0, \
                  remap_args=None,env_args=None, output=None, cwd=None, \
-                 launch_prefix=None, required=False, filename='<unknown>'):
+                 launch_prefix=None, required=False, filename='<unknown>', \
+                 max_logfile_size=None, logfile_count=2):
         """
         :param package: node package name, ``str``
         :param node_type: node type, ``str``
@@ -447,7 +448,10 @@ class Node(object):
         :param launch_prefix: launch command/arguments to prepend to node executable arguments, ``str``
         :param required: node is required to stay running (launch fails if node dies), ``bool``
         :param filename: name of file Node was parsed from, ``str``
-
+        :param max_logfile_size: Maximum Size (in bytes) of the node's logfile. 0 mean unlimitted (default value),
+        this value must >= 0``int``
+        :param logfile_count: If max_logfile_size > 0, and logfile_count > 0, the system will save old log files by
+        appending the extensions .1, .2 etc... This is an optional parameter, default value is 2.
         :raises: :exc:`ValueError` If parameters do not validate
         """        
 
@@ -497,7 +501,14 @@ class Node(object):
         # configuration property
         self.machine = None
 
-        
+        # if we output to a screen, we ignore log file size arguments,
+        # else we must store them as a member value for using them later.
+        if self.output == 'screen':
+            self.max_logfile_size = None
+            self.logfile_count = None
+        else:
+            self.max_logfile_size = max_logfile_size
+            self.logfile_count = logfile_count
         
     def xmltype(self):
         return 'node'
@@ -522,6 +533,8 @@ class Node(object):
             ('name', name_str),
             ('launch-prefix', self.launch_prefix),
             ('required', self.required),
+            ('max_logfile_size', self.max_logfile_size),
+            ('logfile_count', self.logfile_count),
             ]
 
     #TODO: unify with to_remote_xml using a filter_fn

--- a/tools/roslaunch/src/roslaunch/core.py
+++ b/tools/roslaunch/src/roslaunch/core.py
@@ -443,7 +443,7 @@ class Node(object):
         :param remap_args: list of [(from, to)] remapping arguments, ``[(str, str)]``
         :param env_args: list of [(key, value)] of
         additional environment vars to set for node, ``[(str, str)]``
-        :param output: where to log output to, either Node, 'screen' or 'log', ``str``
+        :param output: where to log output to, 'screen', 'log' or both, ``str``
         :param cwd: current working directory of node, either 'node', 'ROS_HOME'. Default: ROS_HOME, ``str``
         :param launch_prefix: launch command/arguments to prepend to node executable arguments, ``str``
         :param required: node is required to stay running (launch fails if node dies), ``bool``
@@ -484,8 +484,8 @@ class Node(object):
             raise ValueError("package must be non-empty")
         if not len(self.type.strip()):
             raise ValueError("type must be non-empty")
-        if not self.output in ['log', 'screen', None]:
-            raise ValueError("output must be one of 'log', 'screen'")
+        if not self.output in ['log', 'screen', 'both', None]:
+            raise ValueError("output must be one of 'log', 'screen' or 'both'")
         if not self.cwd in ['ROS_HOME', 'node', None]:
             raise ValueError("cwd must be one of 'ROS_HOME', 'node'")
         

--- a/tools/roslaunch/src/roslaunch/nodeprocess.py
+++ b/tools/roslaunch/src/roslaunch/nodeprocess.py
@@ -49,7 +49,10 @@ from roslaunch.core import *
 from roslaunch.node_args import create_local_process_args
 from roslaunch.pmon import Process, FatalProcessLaunch
 
+import threading
+
 import logging
+from logging import handlers
 _logger = logging.getLogger("roslaunch")
 
 _TIMEOUT_SIGINT  = 15.0 #seconds
@@ -139,7 +142,25 @@ def create_node_process(run_id, node, master_uri):
     _logger.debug('process[%s]: returning LocalProcess wrapper')
     return LocalProcess(run_id, node.package, name, args, env, log_output, \
             respawn=node.respawn, respawn_delay=node.respawn_delay, \
-            required=node.required, cwd=node.cwd)
+            required=node.required, cwd=node.cwd, max_logfile_size=node.max_logfile_size,\
+            logfile_count=node.logfile_count)
+
+
+def stream_reader(stream, level, logger, popen):
+    while popen.poll() is None:
+        line = stream.readline()
+        if level == logging.INFO:
+            logger.info('%s', line.strip())
+        elif level == logging.ERROR:
+            logger.error('%s', line.strip())
+    #logger.handlers[0].flush()
+    #logger.handlers[0].close()
+    # it may be some data into th stream at the end of the process :
+    #line = stream.read()
+    #if level == logging.INFO:
+    #    logger.info('%s', line.strip())
+    #elif level == logging.ERROR:
+    #     logger.error('%s', line.strip())
 
 
 class LocalProcess(Process):
@@ -149,7 +170,7 @@ class LocalProcess(Process):
     
     def __init__(self, run_id, package, name, args, env, log_output,
             respawn=False, respawn_delay=0.0, required=False, cwd=None,
-            is_node=True):
+            is_node=True, max_logfile_size=None, logfile_count=None):
         """
         @param run_id: unique run ID for this roslaunch. Used to
           generate log directory location. run_id may be None if this
@@ -173,6 +194,10 @@ class LocalProcess(Process):
         @type  cwd: str
         @param is_node: (optional) if True, process is ROS node and accepts ROS node command-line arguments. Default: True
         @type  is_node: False
+        @param max_logfile_size: (optional) Maximum Size (in bytes) of the node's logfile. 0 mean unlimitted (default value),
+        this value must >= 0``int``
+        @param logfile_count: (optional) If max_logfile_size > 0, and logfile_count > 0, the system will save old log
+        files by appending the extensions .1, .2 etc... This is an optional parameter, default value is 2.
         """    
         super(LocalProcess, self).__init__(package, name, args, env,
                 respawn, respawn_delay, required)
@@ -185,6 +210,10 @@ class LocalProcess(Process):
         self.log_dir = None
         self.pid = -1
         self.is_node = is_node
+        self.max_logfile_size = max_logfile_size
+        self.logfile_count = logfile_count
+        self.logThreadError = None
+        self.logThreadInfo = None
 
     # NOTE: in the future, info() is going to have to be sufficient for relaunching a process
     def get_info(self):
@@ -226,7 +255,7 @@ class LocalProcess(Process):
         # open in append mode
         # note: logfileerr: disabling in favor of stderr appearing in the console.
         # will likely reinstate once roserr/rosout is more properly used.
-        logfileout = logfileerr = None
+        logger = None
         logfname = self._log_name()
         
         if self.log_output:
@@ -235,9 +264,29 @@ class LocalProcess(Process):
                 mode = 'a'
             else:
                 mode = 'w'
-            logfileout = open(outf, mode)
+            # we create a logger, and we add to it :
+            logger = logging.getLogger(self.package+'.'+self.name)
+            # we don't propagate logs into the hierarchy. If we do it, when the node will be killed, some unwanted
+            # stdout will be displayed on the console...
+            logger.propagate = False
+            if self.max_logfile_size:
+                # a rotating file handler if max_logfile_size was set by user in XML launch file.
+                hdlr_out = logging.handlers.RotatingFileHandler(outf, mode=mode, maxBytes=self.max_logfile_size,
+                                                                backupCount=self.logfile_count)
+                if is_child_mode():
+                    hdlr_err = logging.handlers.RotatingFileHandler(errf, mode=mode, maxBytes=self.max_logfile_size,
+                                                                    backupCount=self.logfile_count)
+            else:
+                # a simple file to have the same behaviour as before :
+                hdlr_out = logging.FileHandler(outf, mode=mode)
+                if is_child_mode():
+                    hdlr_err = logging.FileHandler(errf, mode=mode)
+
+            hdlr_out.setLevel(logging.INFO)
+            logger.addHandler(hdlr_out)
             if is_child_mode():
-                logfileerr = open(errf, mode)
+                hdlr_err.setLevel(logging.ERROR)
+                logger.addHandler(hdlr_err)
 
         # #986: pass in logfile name to node
         node_log_file = log_dir
@@ -246,7 +295,7 @@ class LocalProcess(Process):
             self.args = _cleanup_remappings(self.args, '__log:=')
             self.args.append("__log:=%s"%os.path.join(log_dir, "%s.log"%(logfname)))
 
-        return logfileout, logfileerr
+        return logger
 
     def start(self):
         """
@@ -267,15 +316,24 @@ class LocalProcess(Process):
             full_env = self.env
 
             # _configure_logging() can mutate self.args
+            process_logger = None
             try:
-                logfileout, logfileerr = self._configure_logging()
+                process_logger = self._configure_logging()
             except Exception as e:
                 _logger.error(traceback.format_exc())
                 printerrlog("[%s] ERROR: unable to configure logging [%s]"%(self.name, str(e)))
                 # it's not safe to inherit from this process as
                 # rostest changes stdout to a StringIO, which is not a
                 # proper file.
+                #logfileout, logfileerr = subprocess.PIPE, subprocess.PIPE
+
+            #if we must log into a file (so process_logger exists) :
+            if process_logger:
+                # stdout and stderr must of subprocess must be redirected to a pipe
                 logfileout, logfileerr = subprocess.PIPE, subprocess.PIPE
+            else:
+                # stdout and stderr must of subprocess must be displayed on the screen.
+                logfileout, logfileerr = None, None
 
             if self.cwd == 'node':
                 cwd = os.path.dirname(self.args[0])
@@ -304,8 +362,19 @@ class LocalProcess(Process):
 Please make sure that all the executables in this command exist and have
 executable permission. This is often caused by a bad launch-prefix."""%(msg, ' '.join(self.args)))
                 else:
-                    raise FatalProcessLaunch("unable to launch [%s]: %s"%(' '.join(self.args), msg))
-                
+                    raise FatalProcessLaunch("unable to launch [%s]: %s"%(' '.join(self.args), e.strerror))
+
+            # we redirect subprocess output to proper loglevel in a dedicated thread :
+            if logfileout:
+                self.logThreadInfo = threading.Thread(target=stream_reader, args=(self.popen.stdout, logging.INFO,
+                                                                                  process_logger, self.popen))
+                self.logThreadInfo.start()
+
+            if logfileerr:
+                self.logThreadError = threading.Thread(target=stream_reader, args=(self.popen.stderr, logging.ERROR,
+                                                                                   process_logger, self.popen))
+                self.logThreadError.start()
+
             self.started = True
             # Check that the process is either still running (poll returns
             # None) or that it completed successfully since when we
@@ -421,6 +490,12 @@ executable permission. This is often caused by a bad launch-prefix."""%(msg, ' '
                 _logger.info("process[%s]: SIGINT killed with return value %s", self.name, retcode)
                 
         finally:
+            if self.logThreadError:
+                _logger.info("process[%s]: Joining log Error thread")
+                self.logThreadError.join()
+            if self.logThreadInfo:
+                _logger.info("process[%s]: Joining log Info thread")
+                self.logThreadInfo.join()
             self.popen = None
 
     def _stop_win32(self, errors):
@@ -488,6 +563,10 @@ executable permission. This is often caused by a bad launch-prefix."""%(msg, ' '
             else:
                 _logger.info("process[%s]: SIGINT killed with return value %s", self.name, retcode)
         finally:
+            if self.logThreadError:
+                self.logThreadError.join()
+            if self.logThreadInfo:
+                self.logThreadInfo.join()
             self.popen = None
 			
     def stop(self, errors=None):

--- a/tools/roslaunch/src/roslaunch/nodeprocess.py
+++ b/tools/roslaunch/src/roslaunch/nodeprocess.py
@@ -90,7 +90,8 @@ def create_master_process(run_id, type_, ros_root, port):
 
     _logger.info("process[master]: launching with args [%s]"%args)
     log_output = False
-    return LocalProcess(run_id, package, 'master', args, os.environ, log_output, None)
+    screen_output = True
+    return LocalProcess(run_id, package, 'master', args, os.environ, log_output, screen_output, None)
 
 def create_node_process(run_id, node, master_uri):
     """
@@ -138,13 +139,20 @@ def create_node_process(run_id, node, master_uri):
     _logger.info('process[%s]: args[%s]', name, args)        
 
     # default for node.output not set is 'log'
-    log_output = node.output != 'screen'
+    if node.output == 'screen':
+        log_output = False
+        screen_output = True
+    elif node.output == 'both':
+        log_output = True
+        screen_output = True
+    else:
+        log_output = True
+        screen_output = False
     _logger.debug('process[%s]: returning LocalProcess wrapper')
-    return LocalProcess(run_id, node.package, name, args, env, log_output, \
+    return LocalProcess(run_id, node.package, name, args, env, log_output, screen_output,\
             respawn=node.respawn, respawn_delay=node.respawn_delay, \
             required=node.required, cwd=node.cwd, max_logfile_size=node.max_logfile_size,\
             logfile_count=node.logfile_count)
-
 
 def stream_reader(stream, level, logger, popen):
     while popen.poll() is None:
@@ -153,22 +161,13 @@ def stream_reader(stream, level, logger, popen):
             logger.info('%s', line.strip())
         elif level == logging.ERROR:
             logger.error('%s', line.strip())
-    #logger.handlers[0].flush()
-    #logger.handlers[0].close()
-    # it may be some data into th stream at the end of the process :
-    #line = stream.read()
-    #if level == logging.INFO:
-    #    logger.info('%s', line.strip())
-    #elif level == logging.ERROR:
-    #     logger.error('%s', line.strip())
-
 
 class LocalProcess(Process):
     """
     Process launched on local machine
     """
     
-    def __init__(self, run_id, package, name, args, env, log_output,
+    def __init__(self, run_id, package, name, args, env, log_output, screen_output,
             respawn=False, respawn_delay=0.0, required=False, cwd=None,
             is_node=True, max_logfile_size=None, logfile_count=None):
         """
@@ -186,6 +185,8 @@ class LocalProcess(Process):
         @type  env: {str : str}
         @param log_output: if True, log output streams of process
         @type  log_output: bool
+        @param screen_output: if True, show process output on screen
+        @type  screen_output: bool
         @param respawn: respawn process if it dies (default is False)
         @type  respawn: bool
         @param respawn_delay: respawn process after a delay
@@ -204,6 +205,7 @@ class LocalProcess(Process):
         self.run_id = run_id
         self.popen = None
         self.log_output = log_output
+        self.screen_output = screen_output
         self.started = False
         self.stopped = False
         self.cwd = cwd
@@ -235,7 +237,7 @@ class LocalProcess(Process):
         @return: stdout log file name, stderr log file
         name. Values are None if stdout/stderr are not logged.
         @rtype: str, str
-        """    
+        """
         log_dir = rospkg.get_log_dir(env=os.environ)
         static_log = os.environ.get('ROS_STATIC_LOG_FILE_NAMES', 0) == '1'
         if self.run_id and not static_log:
@@ -255,29 +257,29 @@ class LocalProcess(Process):
         # open in append mode
         # note: logfileerr: disabling in favor of stderr appearing in the console.
         # will likely reinstate once roserr/rosout is more properly used.
-        logger = None
-        logfname = self._log_name()
-        
+
+        # we create a logger (and we will add to it either a StreamHandler or a FileHandler
+        logger = logging.getLogger(self.package+'.'+self.name)
+        #if we must write on file :
         if self.log_output:
+            logfname = self._log_name()
             outf, errf = [os.path.join(log_dir, '%s-%s.log'%(logfname, n)) for n in ['stdout', 'stderr']]
             if self.respawn or static_log:
                 mode = 'a'
             else:
                 mode = 'w'
-            # we create a logger, and we add to it :
-            logger = logging.getLogger(self.package+'.'+self.name)
             # we don't propagate logs into the hierarchy. If we do it, when the node will be killed, some unwanted
             # stdout will be displayed on the console...
             logger.propagate = False
             if self.max_logfile_size:
-                # a rotating file handler if max_logfile_size was set by user in XML launch file.
+                # We create a rotating file handler if max_logfile_size was set by user in XML launch file.
                 hdlr_out = logging.handlers.RotatingFileHandler(outf, mode=mode, maxBytes=self.max_logfile_size,
                                                                 backupCount=self.logfile_count)
                 if is_child_mode():
                     hdlr_err = logging.handlers.RotatingFileHandler(errf, mode=mode, maxBytes=self.max_logfile_size,
                                                                     backupCount=self.logfile_count)
             else:
-                # a simple file to have the same behaviour as before :
+                # We create a simple file to have the same behaviour as before if there is no maxBytes attributes :
                 hdlr_out = logging.FileHandler(outf, mode=mode)
                 if is_child_mode():
                     hdlr_err = logging.FileHandler(errf, mode=mode)
@@ -287,13 +289,23 @@ class LocalProcess(Process):
             if is_child_mode():
                 hdlr_err.setLevel(logging.ERROR)
                 logger.addHandler(hdlr_err)
+            # #986: pass in logfile name to node
+            node_log_file = log_dir
+            if self.is_node:
+                # #1595: on respawn, these keep appending
+                self.args = _cleanup_remappings(self.args, '__log:=')
+                self.args.append("__log:=%s"%os.path.join(log_dir, "%s.log"%(logfname)))
 
-        # #986: pass in logfile name to node
-        node_log_file = log_dir
-        if self.is_node:
-            # #1595: on respawn, these keep appending
-            self.args = _cleanup_remappings(self.args, '__log:=')
-            self.args.append("__log:=%s"%os.path.join(log_dir, "%s.log"%(logfname)))
+        # if We must log to screen
+        if self.screen_output:
+            # we create handlers for stdout and stderr, and we add them to the logger.
+            hdlr_stdout = logging.StreamHandler(sys.stdout)
+            hdlr_stdout.setLevel(logging.INFO)
+            logger.addHandler(hdlr_stdout)
+            if is_child_mode():
+                hdlr_stderr = logging.StreamHandler(sys.stderr)
+                hdlr_stderr.setLevel(logging.ERROR)
+                logger.addHandler(hdlr_err)
 
         return logger
 
@@ -318,7 +330,7 @@ class LocalProcess(Process):
             # _configure_logging() can mutate self.args
             process_logger = None
             try:
-                process_logger = self._configure_logging()
+                process_logger = self._configure_logging() # Must always return an object even if we log only on screen.
             except Exception as e:
                 _logger.error(traceback.format_exc())
                 printerrlog("[%s] ERROR: unable to configure logging [%s]"%(self.name, str(e)))
@@ -332,7 +344,8 @@ class LocalProcess(Process):
                 # stdout and stderr must of subprocess must be redirected to a pipe
                 logfileout, logfileerr = subprocess.PIPE, subprocess.PIPE
             else:
-                # stdout and stderr must of subprocess must be displayed on the screen.
+                # stdout and stderr must of subprocess must be displayed on the screen because a problem occur when
+                # configuring the logger
                 logfileout, logfileerr = None, None
 
             if self.cwd == 'node':
@@ -348,6 +361,10 @@ class LocalProcess(Process):
             _logger.info("process[%s]: cwd will be [%s]", self.name, cwd)
 
             try:
+                if sys.platform.startswith('linux'):
+                    # the two arguments 'stdbuf' and '-oL' are necessary to have real time logging,
+                    # instead of all at once. only necessary if stdout is not a tty
+                    self.args = ['stdbuf', '-oL'] + self.args
                 self.popen = subprocess.Popen(self.args, cwd=cwd, stdout=logfileout, stderr=logfileerr, env=full_env, close_fds=True, preexec_fn=os.setsid)
             except OSError as e:
                 self.started = True # must set so is_alive state is correct

--- a/tools/roslaunch/test/unit/test_xmlloader.py
+++ b/tools/roslaunch/test/unit/test_xmlloader.py
@@ -174,6 +174,24 @@ class TestXmlLoader(unittest.TestCase):
         except roslaunch.xmlloader.XmlParseException:
             pass
 
+    def test_thatLogFileSizeAreParsedAsPositiveInteger(self):
+        loader = roslaunch.xmlloader.XmlLoader()
+        mock = RosLaunchMock()
+        loader.load(os.path.join(self.xml_dir, 'test-valid-logfile-size.xml'), mock)
+        self.assert_(mock.nodes)
+        for node in mock.nodes:
+            if(node.name == 'toto_0'):
+                self.assert_(isinstance(node.max_logfile_size, int))
+                self.assertEqual(node.max_logfile_size, 0)
+            elif(node.name=='toto_1000'):
+                self.assert_(isinstance(node.max_logfile_size, int))
+                self.assertEqual(node.max_logfile_size, 1000)
+        try:
+            loader.load(os.path.join(self.xml_dir, 'test-invalid-logfile-size.xml'), mock)
+            self.fail('invalid log file size was not catched by positive_integer parser !')
+        except roslaunch.xmlloader.XmlParseException:
+            pass
+
     def test_params_invalid(self):
         tests = ['test-params-invalid-%s.xml'%i for i in range(1, 6)]
         loader = roslaunch.xmlloader.XmlLoader()

--- a/tools/roslaunch/test/xml/test-invalid-logfile-size.xml
+++ b/tools/roslaunch/test/xml/test-invalid-logfile-size.xml
@@ -1,0 +1,3 @@
+<launch>
+ <node pkg="toto" name="toto" type="toto" max_logfile_size="-1"/>
+</launch>

--- a/tools/roslaunch/test/xml/test-node-valid.xml
+++ b/tools/roslaunch/test/xml/test-node-valid.xml
@@ -77,6 +77,7 @@
   <!-- TODO remap args test -->
 
   <node name="n30" pkg="package" type="test_launch_prefix" launch-prefix="xterm -e gdb --args" />
-  
+ 
+  <node name="n31" pkg="package" type="logfile_size_tester" max_logfile_size="100" logfile_count="2"/>  
 </launch>
 

--- a/tools/roslaunch/test/xml/test-valid-logfile-size.xml
+++ b/tools/roslaunch/test/xml/test-valid-logfile-size.xml
@@ -1,0 +1,4 @@
+<launch>
+ <node type="toto" pkg="toto" name="toto_1000" max_logfile_size="1000"/>
+ <node type="toto" pkg="toto" name="toto_0" max_logfile_size="0"/>
+</launch>


### PR DESCRIPTION
Pulling in unmerged Upstream PR: https://github.com/ros/ros_comm/pull/551

> Here is a patch that allow to keep control on the maximum size of the logfiles.
> Two new attributes have been added to the "node" element of roslaunch XML files :
> - max_logfile_size : a positive or null integer. This is the max size in byte that the logfile of a node will count.
> - logfile_count : a positive or null integer. This is how much logfile will be rotated. To understand how this work, read the RotatingFileHandler of logging.handlers python module.
> 
> Unit Tests :
> - I did some change in test-node-valid.xml, to ensure that adding the two new attributes don't break anything.
> - I added two test XML files which are tested in a new unit test test_xmlloader.py.
> 
> That seem quite complexe to automate the testing of the feature I introduce in this patch (launching a node, and test that a rotating log file is created). So I only test it "by hand" analyzing a log folder when launching some big projects I do in my company, and some trivial launch files...

indigo-rethink cherry-pick Conflicts:
    tools/roslaunch/src/roslaunch/nodeprocess.py
