### PR TITLE
Remove sequence number in log files name

### DIFF
--- a/tools/roslaunch/src/roslaunch/nodeprocess.py
+++ b/tools/roslaunch/src/roslaunch/nodeprocess.py
@@ -121,8 +121,10 @@ def create_node_process(run_id, node, master_uri):
     
     # we have to include the counter to prevent potential name
     # collisions between the two branches
-
-    name = "%s-%s"%(rosgraph.names.ns_join(node.namespace, node.name), _next_counter())
+    if os.environ.get('ROS_STATIC_LOG_FILE_NAMES', 0) == '1':
+        name = "%s"%(rosgraph.names.ns_join(node.namespace, node.name))
+    else:
+        name = "%s-%s"%(rosgraph.names.ns_join(node.namespace, node.name), _next_counter())
     if name[0] == '/':
         name = name[1:]
 


### PR DESCRIPTION
Ignores sequence number in log file names
so that log files have static names
