### PR TITLE
package.xml version template

### DIFF
--- a/clients/roscpp/package.xml
+++ b/clients/roscpp/package.xml
@@ -1,6 +1,6 @@
 <package>
   <name>roscpp</name>
-  <version>1.11.8</version>
+  <version>:{version}</version>
   <description>
     roscpp is a C++ implementation of ROS. It provides
     a <a href="http://www.ros.org/wiki/Client%20Libraries">client

--- a/clients/rospy/package.xml
+++ b/clients/rospy/package.xml
@@ -1,6 +1,6 @@
 <package>
   <name>rospy</name>
-  <version>1.11.8</version>
+  <version>:{version}</version>
   <description>
     rospy is a pure Python client library for ROS. The rospy client
     API enables Python programmers to quickly interface with ROS <a

--- a/ros_comm/package.xml
+++ b/ros_comm/package.xml
@@ -1,6 +1,6 @@
 <package>
   <name>ros_comm</name>
-  <version>1.11.8</version>
+  <version>:{version}</version>
   <description>
     ROS communications-related packages, including core client libraries (roscpp, rospy) and graph introspection tools (rostopic, rosnode, rosservice, rosparam).
   </description>

--- a/test/test_rosbag/package.xml
+++ b/test/test_rosbag/package.xml
@@ -1,6 +1,6 @@
 <package>
   <name>test_rosbag</name>
-  <version>1.11.8</version>
+  <version>:{version}</version>
   <description>
     A package containing the unit tests for rosbag.
   </description>

--- a/test/test_rosbag_storage/package.xml
+++ b/test/test_rosbag_storage/package.xml
@@ -1,6 +1,6 @@
 <package>
   <name>test_rosbag_storage</name>
-  <version>1.11.8</version>
+  <version>:{version}</version>
   <description>
     A package containing the unit tests for rosbag_storage.
   </description>

--- a/test/test_roscpp/package.xml
+++ b/test/test_roscpp/package.xml
@@ -1,6 +1,6 @@
 <package>
   <name>test_roscpp</name>
-  <version>1.11.8</version>
+  <version>:{version}</version>
   <description>
     Tests for roscpp which depend on rostest.
   </description>

--- a/test/test_rosgraph/package.xml
+++ b/test/test_rosgraph/package.xml
@@ -1,6 +1,6 @@
 <package>
   <name>test_rosgraph</name>
-  <version>1.11.8</version>
+  <version>:{version}</version>
   <description>
     Tests for rosgraph which depend on rostest.
   </description>

--- a/test/test_roslaunch/package.xml
+++ b/test/test_roslaunch/package.xml
@@ -1,6 +1,6 @@
 <package>
   <name>test_roslaunch</name>
-  <version>1.11.8</version>
+  <version>:{version}</version>
   <description>
     Tests for roslaunch which depend on rostest.
   </description>

--- a/test/test_roslib_comm/package.xml
+++ b/test/test_roslib_comm/package.xml
@@ -1,6 +1,6 @@
 <package>
   <name>test_roslib_comm</name>
-  <version>1.11.8</version>
+  <version>:{version}</version>
   <description>
     Unit tests verifying that roslib is operating as expected.
   </description>

--- a/test/test_rosmaster/package.xml
+++ b/test/test_rosmaster/package.xml
@@ -1,6 +1,6 @@
 <package>
   <name>test_rosmaster</name>
-  <version>1.11.8</version>
+  <version>:{version}</version>
   <description>
     Tests for rosmaster which depend on rostest.
   </description>

--- a/test/test_rosparam/package.xml
+++ b/test/test_rosparam/package.xml
@@ -1,6 +1,6 @@
 <package>
   <name>test_rosparam</name>
-  <version>1.11.8</version>
+  <version>:{version}</version>
   <description>
     A package containing the unit tests for rosparam.
   </description>

--- a/test/test_rospy/package.xml
+++ b/test/test_rospy/package.xml
@@ -1,6 +1,6 @@
 <package>
   <name>test_rospy</name>
-  <version>1.11.8</version>
+  <version>:{version}</version>
   <description>
     rospy unit and integration test framework.
   </description>

--- a/test/test_rosservice/package.xml
+++ b/test/test_rosservice/package.xml
@@ -1,6 +1,6 @@
 <package>
   <name>test_rosservice</name>
-  <version>1.11.8</version>
+  <version>:{version}</version>
   <description>
     Tests for the rosservice tool.
   </description>

--- a/tools/rosbag/package.xml
+++ b/tools/rosbag/package.xml
@@ -1,6 +1,6 @@
 <package>
   <name>rosbag</name>
-  <version>1.11.8</version>
+  <version>:{version}</version>
   <description>
     This is a set of tools for recording from and playing back to ROS
     topics.  It is intended to be high performance and avoids

--- a/tools/rosbag_storage/package.xml
+++ b/tools/rosbag_storage/package.xml
@@ -1,6 +1,6 @@
 <package>
   <name>rosbag_storage</name>
-  <version>1.11.8</version>
+  <version>:{version}</version>
   <description>
     This is a set of tools for recording from and playing back ROS
     message without relying on the ROS client library.

--- a/tools/rosconsole/package.xml
+++ b/tools/rosconsole/package.xml
@@ -1,6 +1,6 @@
 <package>
   <name>rosconsole</name>
-  <version>1.11.8</version>
+  <version>:{version}</version>
   <description>ROS console output library.</description>
   <maintainer email="dthomas@osrfoundation.org">Dirk Thomas</maintainer>
   <license>BSD</license>

--- a/tools/rosgraph/package.xml
+++ b/tools/rosgraph/package.xml
@@ -1,6 +1,6 @@
 <package>
   <name>rosgraph</name>
-  <version>1.11.8</version>
+  <version>:{version}</version>
   <description>
     rosgraph contains the rosgraph command-line tool, which prints
     information about the ROS Computation Graph. It also provides an

--- a/tools/roslaunch/package.xml
+++ b/tools/roslaunch/package.xml
@@ -1,6 +1,6 @@
 <package>
   <name>roslaunch</name>
-  <version>1.11.8</version>
+  <version>:{version}</version>
   <description>
     roslaunch is a tool for easily launching multiple ROS <a
     href="http://ros.org/wiki/Nodes">nodes</a> locally and remotely

--- a/tools/rosmaster/package.xml
+++ b/tools/rosmaster/package.xml
@@ -1,6 +1,6 @@
 <package>
   <name>rosmaster</name>
-  <version>1.11.8</version>
+  <version>:{version}</version>
   <description>
     ROS <a href="http://ros.org/wiki/Master">Master</a> implementation.
   </description>

--- a/tools/rosmsg/package.xml
+++ b/tools/rosmsg/package.xml
@@ -1,6 +1,6 @@
 <package>
   <name>rosmsg</name>
-  <version>1.11.8</version>
+  <version>:{version}</version>
   <description>
     rosmsg contains two command-line tools: <tt>rosmsg</tt> and
     <tt>rossrv</tt>. <tt>rosmsg</tt> is a command-line tool for

--- a/tools/rosnode/package.xml
+++ b/tools/rosnode/package.xml
@@ -1,6 +1,6 @@
 <package>
   <name>rosnode</name>
-  <version>1.11.8</version>
+  <version>:{version}</version>
   <description>
     rosnode is a command-line tool for displaying debug information
     about ROS <a href="http://www.ros.org/wiki/Nodes">Nodes</a>,

--- a/tools/rosout/package.xml
+++ b/tools/rosout/package.xml
@@ -1,6 +1,6 @@
 <package>
   <name>rosout</name>
-  <version>1.11.8</version>
+  <version>:{version}</version>
   <description>
      System-wide logging mechanism for messages sent to the /rosout topic.
   </description>

--- a/tools/rosparam/package.xml
+++ b/tools/rosparam/package.xml
@@ -1,6 +1,6 @@
 <package>
   <name>rosparam</name>
-  <version>1.11.8</version>
+  <version>:{version}</version>
   <description>
     rosparam contains the rosparam command-line tool for getting and
     setting ROS Parameters on the <a

--- a/tools/rosservice/package.xml
+++ b/tools/rosservice/package.xml
@@ -1,6 +1,6 @@
 <package>
   <name>rosservice</name>
-  <version>1.11.8</version>
+  <version>:{version}</version>
   <description>
     rosservice contains the rosservice command-line tool for listing
     and querying ROS <a

--- a/tools/rostest/package.xml
+++ b/tools/rostest/package.xml
@@ -1,6 +1,6 @@
 <package>
   <name>rostest</name>
-  <version>1.11.8</version>
+  <version>:{version}</version>
   <description>
      Integration test suite based on roslaunch that is compatible with xUnit frameworks.
   </description>

--- a/tools/rostopic/package.xml
+++ b/tools/rostopic/package.xml
@@ -1,6 +1,6 @@
 <package>
   <name>rostopic</name>
-  <version>1.11.8</version>
+  <version>:{version}</version>
   <description>
     rostopic contains the rostopic command-line tool for displaying
     debug information about

--- a/tools/topic_tools/package.xml
+++ b/tools/topic_tools/package.xml
@@ -1,6 +1,6 @@
 <package>
   <name>topic_tools</name>
-  <version>1.11.8</version>
+  <version>:{version}</version>
   <description>
     Tools for directing, throttling, selecting, and otherwise messing with
     ROS topics at a meta level. None of the programs in this package actually

--- a/utilities/message_filters/package.xml
+++ b/utilities/message_filters/package.xml
@@ -1,6 +1,6 @@
 <package>
   <name>message_filters</name>
-  <version>1.11.8</version>
+  <version>:{version}</version>
   <description>
     A set of message filters which take in messages and may output those messages at a later time, based on the conditions that filter needs met.
   </description>

--- a/utilities/roslz4/package.xml
+++ b/utilities/roslz4/package.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <package>
   <name>roslz4</name>
-  <version>1.11.8</version>
+  <version>:{version}</version>
   <description>
     A Python and C++ implementation of the LZ4 streaming format.  Large data
     streams are split into blocks which are compressed using the very fast LZ4

--- a/utilities/roswtf/package.xml
+++ b/utilities/roswtf/package.xml
@@ -1,6 +1,6 @@
 <package>
   <name>roswtf</name>
-  <version>1.11.8</version>
+  <version>:{version}</version>
   <description>
      roswtf is a tool for diagnosing issues with a running ROS system. Think of it as a FAQ implemented in code.
   </description>

--- a/utilities/xmlrpcpp/package.xml
+++ b/utilities/xmlrpcpp/package.xml
@@ -1,6 +1,6 @@
 <package>
   <name>xmlrpcpp</name>
-  <version>1.11.8</version>
+  <version>:{version}</version>
   <description>
     XmlRpc++ is a C++ implementation of the XML-RPC protocol. This version is
     heavily modified from the package available on SourceForge in order to


### PR DESCRIPTION
Templating the `version` field in a package.xml is pretty neat because it lets you specify the version string at "bloom-time". This is good because it allows you to [`bloom-release` untagged commits](https://github.com/ros-infrastructure/bloom/issues/482#issuecomment-410871816). For this patch, I did one of these...

    find . -type f -name "package.xml" \
        -exec sed -i 's|<version>1.11.8</version>|<version>:{version}</version>|g' {} +

...which I think is what's needed.
